### PR TITLE
Add flow tracking support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,6 @@ mod client;
 mod error;
 mod types;
 
-pub use client::{TimberlogsClient, TimberlogsConfig};
+pub use client::{Flow, RetryConfig, TimberlogsClient, TimberlogsConfig};
 pub use error::TimberlogsError;
 pub use types::{Environment, LogEntry, LogLevel};

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,3 +88,10 @@ pub(crate) struct IngestResponse {
     #[allow(dead_code)]
     pub count: u32,
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FlowResponse {
+    pub flow_id: String,
+    pub name: String,
+}


### PR DESCRIPTION
## Summary
- Add `Flow` API for creating server-side flows via the `/v1/flows` endpoint
- Provide convenience methods (`debug`, `info`, `warn`, `error`) on `Flow` with auto-incrementing step indices
- Re-export `Flow` and `RetryConfig` from the crate root

## Test plan
- [ ] Verify flow creation against the ingest API
- [ ] Verify logs within a flow include correct `flow_id` and `step_index`
- [ ] Confirm step indices auto-increment across chained calls