### PR TITLE
Add raw format ingestion (ingest_raw)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "time", "sync"] }
 thiserror = "2"
+urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ mod types;
 
 pub use client::{Flow, RetryConfig, TimberlogsClient, TimberlogsConfig};
 pub use error::TimberlogsError;
-pub use types::{Environment, LogEntry, LogLevel};
+pub use types::{Environment, IngestRawOptions, LogEntry, LogLevel, RawFormat};

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,3 +95,45 @@ pub(crate) struct FlowResponse {
     pub flow_id: String,
     pub name: String,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RawFormat {
+    Json,
+    Jsonl,
+    Syslog,
+    Text,
+    Csv,
+    Obl,
+}
+
+impl RawFormat {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RawFormat::Json => "json",
+            RawFormat::Jsonl => "jsonl",
+            RawFormat::Syslog => "syslog",
+            RawFormat::Text => "text",
+            RawFormat::Csv => "csv",
+            RawFormat::Obl => "obl",
+        }
+    }
+
+    pub fn content_type(&self) -> &'static str {
+        match self {
+            RawFormat::Json => "application/json",
+            RawFormat::Jsonl => "application/x-ndjson",
+            RawFormat::Syslog => "application/x-syslog",
+            RawFormat::Text => "text/plain",
+            RawFormat::Csv => "text/csv",
+            RawFormat::Obl => "application/x-obl",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct IngestRawOptions {
+    pub source: Option<String>,
+    pub environment: Option<Environment>,
+    pub level: Option<LogLevel>,
+    pub dataset: Option<String>,
+}


### PR DESCRIPTION
## Summary
- Add `RawFormat` enum with variants for json, jsonl, syslog, text, csv, obl
- Add `IngestRawOptions` struct for optional query params (source, environment, level, dataset)
- Add `ingest_raw()` method on `TimberlogsClient` that POSTs raw body to `/v1/logs?format=<format>` with retry logic
- Export new types from crate root

Closes #2

## Test plan
- [ ] Verify each format variant sends the correct content type header
- [ ] Verify optional query params are URL-encoded and appended correctly
- [ ] Verify retry behavior on transient failures