### PR TITLE
Add missing LogEntry fields: timestamp, ip_address, country

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -269,6 +269,9 @@ impl TimberlogsClient {
             flow_id: entry.flow_id,
             step_index: entry.step_index,
             dataset: entry.dataset.or_else(|| self.config.dataset.clone()),
+            timestamp: entry.timestamp,
+            ip_address: entry.ip_address,
+            country: entry.country,
         };
 
         let should_flush = {
@@ -559,6 +562,9 @@ impl Default for LogEntry {
             flow_id: None,
             step_index: None,
             dataset: None,
+            timestamp: None,
+            ip_address: None,
+            country: None,
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -43,6 +43,12 @@ pub struct LogEntry {
     pub step_index: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dataset: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -74,6 +80,12 @@ pub(crate) struct CreateLogArgs {
     pub step_index: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dataset: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary
- Add `timestamp: Option<u64>` (Unix ms, server defaults to now if omitted)
- Add `ip_address: Option<String>` (client IP override)
- Add `country: Option<String>` (country code override)
- Fields added to both `LogEntry` and `CreateLogArgs`, passed through in `log()`

Closes #4

## Test plan
- [ ] Verify new fields serialize correctly when set
- [ ] Verify new fields are omitted from JSON when None
- [ ] Verify existing log calls still work unchanged (Default impl updated)