### PR TITLE
Add field-level validation for all string fields

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -91,6 +91,18 @@ struct ClientConfig {
     on_error: Option<ErrorCallback>,
 }
 
+fn check_str(value: Option<&str>, name: &str, max_len: usize) -> Result<(), TimberlogsError> {
+    if let Some(v) = value {
+        if v.len() > max_len {
+            return Err(TimberlogsError::Validation(format!(
+                "{name} exceeds {max_len} characters: {}",
+                v.len()
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn validate_entry(entry: &LogEntry) -> Result<(), TimberlogsError> {
     if entry.message.is_empty() {
         return Err(TimberlogsError::Validation(
@@ -103,6 +115,15 @@ fn validate_entry(entry: &LogEntry) -> Result<(), TimberlogsError> {
             entry.message.len()
         )));
     }
+    check_str(entry.user_id.as_deref(), "user_id", 100)?;
+    check_str(entry.session_id.as_deref(), "session_id", 100)?;
+    check_str(entry.request_id.as_deref(), "request_id", 100)?;
+    check_str(entry.error_name.as_deref(), "error_name", 200)?;
+    check_str(entry.error_stack.as_deref(), "error_stack", 10_000)?;
+    check_str(entry.flow_id.as_deref(), "flow_id", 100)?;
+    check_str(entry.dataset.as_deref(), "dataset", 50)?;
+    check_str(entry.ip_address.as_deref(), "ip_address", 100)?;
+    check_str(entry.country.as_deref(), "country", 10)?;
     if let Some(ref tags) = entry.tags {
         if tags.len() > 20 {
             return Err(TimberlogsError::Validation(format!(


### PR DESCRIPTION
## Summary
- Add `check_str` helper for consistent string length validation
- Validate all string fields on `LogEntry`: user_id, session_id, request_id, error_name, error_stack, flow_id, dataset, ip_address, country
- Existing message, tags, and step_index validation unchanged

Closes #5

## Test plan
- [ ] Verify each field rejects values exceeding its max length
- [ ] Verify fields at or under the limit pass validation
- [ ] Verify existing log calls still work unchanged